### PR TITLE
Support additional OAS 3 keywords

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,5 @@ dist/
 # AMF models
 /demo/*.json
 !demo/apis.json
+
+.idea/

--- a/demo/apis.json
+++ b/demo/apis.json
@@ -7,5 +7,6 @@
   "SE-11155/SE-11155.raml": "RAML 1.0",
   "APIC-289/APIC-289.yaml": "OAS 2.0",
   "APIC-282/APIC-282.raml": "RAML 1.0",
-  "APIC-429/APIC-429.yaml": { "type": "OAS 3.0", "mime": "application/yaml" }
+  "APIC-429/APIC-429.yaml": { "type": "OAS 3.0", "mime": "application/yaml" },
+  "new-oas3-types/new-oas3-types.yaml": { "type": "OAS 3.0", "mime": "application/yaml" }
 }

--- a/demo/index.js
+++ b/demo/index.js
@@ -121,6 +121,7 @@ class ApiDemo extends ApiDemoPage {
       ['SE-11155', 'SE-11155'],
       ['demo-api-v4', 'Demo Api - AMF v4'],
       ['APIC-282', 'APIC-282'],
+      ['new-oas3-types', 'New OAS 3 types API'],
     ].map(
       ([file, label]) => html` <paper-item data-src="${file}-compact.json"
           >${label} - compact model</paper-item

--- a/demo/index.js
+++ b/demo/index.js
@@ -123,10 +123,10 @@ class ApiDemo extends ApiDemoPage {
       ['APIC-282', 'APIC-282'],
       ['new-oas3-types', 'New OAS 3 types API'],
     ].map(
-      ([file, label]) => html` <paper-item data-src="${file}-compact.json"
-          >${label} - compact model</paper-item
+      ([file, label]) => html` <anypoint-item data-src="${file}-compact.json"
+          >${label} - compact model</anypoint-item
         >
-        <paper-item data-src="${file}.json">${label}</paper-item>`
+        <anypoint-item data-src="${file}.json">${label}</anypoint-item>`
     );
   }
 

--- a/demo/new-oas3-types/new-oas3-types.yaml
+++ b/demo/new-oas3-types/new-oas3-types.yaml
@@ -1,0 +1,79 @@
+openapi: 3.0.1
+info:
+  title: New OAS 3 types API
+  version: v1
+components:
+  schemas:
+    Person:
+      type: object
+      properties:
+        pets:
+          type: array
+          items:
+            $ref: '#/components/schemas/Pet'
+    Pet:
+      oneOf:
+        - $ref: '#/components/schemas/Cat'
+        - $ref: '#/components/schemas/Dog'
+        - $ref: '#/components/schemas/Tiger'
+    Animal:
+      type: object
+      discriminator:
+        propertyName: petType
+      properties:
+        name:
+          type: string
+        petType:
+          type: string
+      required:
+        - name
+        - petType
+    Cat:  ## "Cat" will be used as the discriminator value
+      description: A representation of a cat
+      allOf:
+        - $ref: '#/components/schemas/Animal'
+        - type: object
+          properties:
+            huntingSkill:
+              type: string
+              description: The measured skill for hunting
+              enum:
+                - clueless
+                - lazy
+                - adventurous
+                - aggressive
+          required:
+            - huntingSkill
+    Dog:  ## "Dog" will be used as the discriminator value
+      description: A representation of a dog
+      allOf:
+        - $ref: '#/components/schemas/Animal'
+        - type: object
+          properties:
+            packSize:
+              type: integer
+              format: int32
+              description: the size of the pack the dog is from
+              default: 0
+              minimum: 0
+          required:
+            - packSize
+    Tiger:
+      description: A representation of a Tiger
+      type: object
+      properties:
+        deadliness:
+          type: number
+paths:
+  /pets:
+    get:
+      description: Returns all available pets
+      responses:
+        200:
+          description: List of pets
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  - $ref: '#/components/schemas/Pet'

--- a/demo/new-oas3-types/new-oas3-types.yaml
+++ b/demo/new-oas3-types/new-oas3-types.yaml
@@ -28,6 +28,11 @@ components:
       required:
         - name
         - petType
+    Monster:
+      anyOf:
+        - $ref: '#/components/schemas/Cat'
+        - $ref: '#/components/schemas/Dog'
+        - $ref: '#/components/schemas/Tiger'
     Cat:  ## "Cat" will be used as the discriminator value
       description: A representation of a cat
       allOf:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@api-components/api-type-document",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -316,9 +316,9 @@
       }
     },
     "@api-components/amf-helper-mixin": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@api-components/amf-helper-mixin/-/amf-helper-mixin-4.1.5.tgz",
-      "integrity": "sha512-1lFpHyT96SuQmuFCxDhRWFz0vZh1R39SAvm7WgWIfZliQsnkl5OtK8S0g8MK93u4iipcJOSmwoJ2vFvZOwTbxA=="
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@api-components/amf-helper-mixin/-/amf-helper-mixin-4.1.6.tgz",
+      "integrity": "sha512-MjUz5FyCC7gRNW6ScnDSv9R0FI6SMfIfE2Sj7xSxLEW71t5IRjhFb/0CdhK927hjXj2Tj3OfZrCU/10Cp9nqGw=="
     },
     "@api-components/api-annotation-document": {
       "version": "4.0.3",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@api-components/api-type-document",
   "description": "A documentation table for type (resource) properties. Works with AMF data model",
-  "version": "4.1.1",
+  "version": "4.1.2",
   "license": "Apache-2.0",
   "main": "index.js",
   "module": "index.js",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@advanced-rest-client/arc-marked": "^1.0.6",
     "@advanced-rest-client/markdown-styles": "^3.1.2",
     "@anypoint-web-components/anypoint-button": "^1.1.1",
-    "@api-components/amf-helper-mixin": "^4.1.5",
+    "@api-components/amf-helper-mixin": "^4.1.6",
     "@api-components/api-annotation-document": "^4.0.3",
     "@api-components/api-resource-example-document": "^4.0.8",
     "@api-components/raml-aware": "^3.0.0",

--- a/src/ApiTypeDocument.d.ts
+++ b/src/ApiTypeDocument.d.ts
@@ -153,8 +153,9 @@ export class ApiTypeDocument extends PropertyDocumentMixin(LitElement) {
    * Resets union selection when union types list changes.
    *
    * @param types List of current union types.
+   * @param property Name of field to change
    */
-  _unionTypesChanged(types: object[]): void;
+  _multiTypesChanged(property: string, types: object[]): void;
 
   /**
    * Handler for union type button click.
@@ -167,9 +168,10 @@ export class ApiTypeDocument extends PropertyDocumentMixin(LitElement) {
    *
    * @param type Current `type` value.
    * @param selected Selected union index from `unionTypes` array
+   * @param key Key of the property to look in
    * @returns Properties for union type.
    */
-  _computeUnionProperty(type: Object, selected: number): Object[]|undefined;
+  _computeProperty(type: Object, key: string, selected: number): Object[]|undefined;
 
   /**
    * Helper function for the view. Extracts `http://www.w3.org/ns/shacl#property`

--- a/src/PropertyDocumentMixin.d.ts
+++ b/src/PropertyDocumentMixin.d.ts
@@ -106,9 +106,13 @@ interface PropertyDocumentMixin {
   _computeIsArray(range: Object): boolean;
 
   /**
-   * Computes list of union type labels to render.
+   * Computes list of type labels to render.
+   *
+   * @param {Object} range
+   * @param {String} key Key to look for values in
+   * @return {Array<Object>}
    */
-  _computeUnionTypes(isUnion: boolean, range: Object): Object[];
+  _computeTypes(range, key);
 
   /**
    * Computes union type label when the union is in Array.

--- a/src/PropertyDocumentMixin.js
+++ b/src/PropertyDocumentMixin.js
@@ -330,12 +330,23 @@ const mxFunction = (base) => {
 
     /**
      * Computes list of oneOf type labels to render.
-     *
      * @param {Object} range
      * @return {Array<Object>}
+     * @private
      */
     _computeOneOfTypes(range) {
       const key = this._getAmfKey(this.ns.w3.shacl.xone);
+      return this._computeTypes(range, key);
+    }
+
+    /**
+     * Computes list of anyOf type labels to render.
+     * @param {Object} range
+     * @return {Array<Object>}
+     * @private
+     */
+    _computeAnyOfTypes(range) {
+      const key = this._getAmfKey(this.ns.w3.shacl.or);
       return this._computeTypes(range, key);
     }
 

--- a/src/PropertyDocumentMixin.js
+++ b/src/PropertyDocumentMixin.js
@@ -275,14 +275,15 @@ const mxFunction = (base) => {
           return this._ensureArray(item);
         case this._hasType(item, this.ns.aml.vocabularies.shapes.UnionShape):
         case this._hasType(item, this.ns.aml.vocabularies.shapes.ArrayShape):
+        case this._hasProperty(item, 'http://www.w3.org/ns/shacl#xone'):
           item.isType = true;
           return [item];
         default: {
           const pkey = this._getAmfKey(this.ns.w3.shacl.property);
           const items = this._ensureArray(item[pkey]);
           if (items) {
-            /* eslint-disable-next-line no-param-reassign */
             items.forEach((i) => {
+              /* eslint-disable-next-line no-param-reassign */
               i.isShape = true;
             });
           }
@@ -328,6 +329,17 @@ const mxFunction = (base) => {
     }
 
     /**
+     * Computes list of oneOf type labels to render.
+     *
+     * @param {Object} range
+     * @return {Array<Object>}
+     */
+    _computeOneOfTypes(range) {
+      const key = this._getAmfKey(this.ns.w3.shacl.xone);
+      return this._computeTypes(range, key);
+    }
+
+    /**
      * Computes list of union type labels to render.
      *
      * @param {Boolean} isUnion
@@ -339,6 +351,16 @@ const mxFunction = (base) => {
         return undefined;
       }
       const key = this._getAmfKey(this.ns.aml.vocabularies.shapes.anyOf);
+      return this._computeTypes(range, key);
+    }
+
+    /**
+     * Computes list of type labels to render.
+     *
+     * @param {Object} range
+     * @return {Array<Object>}
+     */
+    _computeTypes(range, key) {
       const list = this._ensureArray(range[key]);
       if (!list) {
         return undefined;

--- a/src/PropertyDocumentMixin.js
+++ b/src/PropertyDocumentMixin.js
@@ -329,46 +329,10 @@ const mxFunction = (base) => {
     }
 
     /**
-     * Computes list of oneOf type labels to render.
-     * @param {Object} range
-     * @return {Array<Object>}
-     * @private
-     */
-    _computeOneOfTypes(range) {
-      const key = this._getAmfKey(this.ns.w3.shacl.xone);
-      return this._computeTypes(range, key);
-    }
-
-    /**
-     * Computes list of anyOf type labels to render.
-     * @param {Object} range
-     * @return {Array<Object>}
-     * @private
-     */
-    _computeAnyOfTypes(range) {
-      const key = this._getAmfKey(this.ns.w3.shacl.or);
-      return this._computeTypes(range, key);
-    }
-
-    /**
-     * Computes list of union type labels to render.
-     *
-     * @param {Boolean} isUnion
-     * @param {Object} range
-     * @return {Array<Object>}
-     */
-    _computeUnionTypes(isUnion, range) {
-      if (!isUnion || !range) {
-        return undefined;
-      }
-      const key = this._getAmfKey(this.ns.aml.vocabularies.shapes.anyOf);
-      return this._computeTypes(range, key);
-    }
-
-    /**
      * Computes list of type labels to render.
      *
      * @param {Object} range
+     * @param {String} key Key to look for values in
      * @return {Array<Object>}
      */
     _computeTypes(range, key) {

--- a/src/TypeStyles.js
+++ b/src/TypeStyles.js
@@ -56,7 +56,8 @@ export default css`
   }
 
   .union-toggle,
-  .one-of-toggle {
+  .one-of-toggle,
+  .any-of-toggle {
     outline: none;
     background-color: var(
       --api-type-document-union-button-background-color,
@@ -69,7 +70,8 @@ export default css`
   }
 
   .union-toggle[activated],
-  .one-of-toggle[activated] {
+  .one-of-toggle[activated],
+  .any-of-toggle[activated] {
     background-color: var(
       --api-type-document-union-button-active-background-color,
       #cddc39

--- a/src/TypeStyles.js
+++ b/src/TypeStyles.js
@@ -55,7 +55,8 @@ export default css`
     );
   }
 
-  .union-toggle {
+  .union-toggle,
+  .one-of-toggle {
     outline: none;
     background-color: var(
       --api-type-document-union-button-background-color,
@@ -67,7 +68,8 @@ export default css`
     border-style: solid;
   }
 
-  .union-toggle[activated] {
+  .union-toggle[activated],
+  .one-of-toggle[activated] {
     background-color: var(
       --api-type-document-union-button-active-background-color,
       #cddc39

--- a/test/api-type-document.test.js
+++ b/test/api-type-document.test.js
@@ -4,6 +4,7 @@ import { tap } from '@polymer/iron-test-helpers/mock-interactions.js';
 import '../api-type-document.js';
 
 describe('<api-type-document>', function () {
+  const newOas3Types = 'new-oas3-types';
   async function basicFixture() {
     return await fixture(`<api-type-document></api-type-document>`);
   }
@@ -767,6 +768,40 @@ describe('<api-type-document>', function () {
           assert.isTrue(u2.isType, 'Union2 is type');
           assert.equal(u2.label, 'PropertyExamples', 'Union2 has name');
         });
+      });
+    });
+  });
+
+  [
+    ['Regular model - OAS 3 types additions', false],
+    ['Compact model - OAS 3 types additions', true]
+  ].forEach(([name, compact]) => {
+    describe(name, () => {
+      let element;
+      let amf;
+
+      beforeEach(async () => {
+        element = await basicFixture();
+        amf = await AmfLoader.load(compact, newOas3Types);
+      });
+
+      it('should represent type as oneOf', async () => {
+        element.amf = amf;
+        const [_, type] = await AmfLoader.loadType('Pet', compact, newOas3Types)
+        element.type = type;
+        await aTimeout(0);
+        assert.lengthOf(element.oneOfTypes, 3);
+        assert.equal(element.isOneOf, true);
+      });
+
+      it('changes selectedOneOf when button clicked', async () => {
+        element.amf = amf;
+        const [_, type] = await AmfLoader.loadType('Pet', compact, newOas3Types)
+        element.type = type;
+        await aTimeout(0);
+        assert.equal(element.selectedOneOf, 0);
+        element.shadowRoot.querySelectorAll('.one-of-toggle')[1].click()
+        assert.equal(element.selectedOneOf, 1);
       });
     });
   });

--- a/test/api-type-document.test.js
+++ b/test/api-type-document.test.js
@@ -778,16 +778,14 @@ describe('<api-type-document>', function () {
   ].forEach(([name, compact]) => {
     describe(name, () => {
       let element;
-      let amf;
 
       beforeEach(async () => {
         element = await basicFixture();
-        amf = await AmfLoader.load(compact, newOas3Types);
       });
 
       it('should represent type as oneOf', async () => {
+        const [amf, type] = await AmfLoader.loadType('Pet', compact, newOas3Types)
         element.amf = amf;
-        const [_, type] = await AmfLoader.loadType('Pet', compact, newOas3Types)
         element.type = type;
         await aTimeout(0);
         assert.lengthOf(element.oneOfTypes, 3);
@@ -795,13 +793,32 @@ describe('<api-type-document>', function () {
       });
 
       it('changes selectedOneOf when button clicked', async () => {
+        const [amf, type] = await AmfLoader.loadType('Pet', compact, newOas3Types)
         element.amf = amf;
-        const [_, type] = await AmfLoader.loadType('Pet', compact, newOas3Types)
         element.type = type;
         await aTimeout(0);
         assert.equal(element.selectedOneOf, 0);
         element.shadowRoot.querySelectorAll('.one-of-toggle')[1].click()
         assert.equal(element.selectedOneOf, 1);
+      });
+
+      it('should represent type as anyOf', async () => {
+        const [amf, type] = await AmfLoader.loadType('Monster', compact, newOas3Types)
+        element.amf = amf;
+        element.type = type;
+        await aTimeout(0);
+        assert.lengthOf(element.anyOfTypes, 3);
+        assert.equal(element.isAnyOf, true);
+      });
+
+      it('changes selectedAnyOf when button clicked', async () => {
+        const [amf, type] = await AmfLoader.loadType('Monster', compact, newOas3Types)
+        element.amf = amf;
+        element.type = type;
+        await aTimeout(0);
+        assert.equal(element.selectedAnyOf, 0);
+        element.shadowRoot.querySelectorAll('.any-of-toggle')[1].click()
+        assert.equal(element.selectedAnyOf, 1);
       });
     });
   });

--- a/test/api-type-document.test.js
+++ b/test/api-type-document.test.js
@@ -80,13 +80,13 @@ describe('<api-type-document>', function () {
 
       it('Does nothing whe no argument', () => {
         element.selectedUnion = 1;
-        element._unionTypesChanged();
+        element._multiTypesChanged('selectedUnion');
         assert.equal(element.selectedUnion, 1);
       });
 
       it('Re-sets selected union index', () => {
         element.selectedUnion = 1;
-        element._unionTypesChanged([]);
+        element._multiTypesChanged('selectedUnion', []);
         assert.equal(element.selectedUnion, 0);
       });
     });
@@ -304,39 +304,43 @@ describe('<api-type-document>', function () {
 
       describe('_computeUnionProperty()', () => {
         let element;
+        let key;
+
         beforeEach(async () => {
           element = await basicFixture();
         });
 
-        it('Computes union type', () => {
-          return AmfLoader.loadType('Unionable', item[1]).then((data) => {
-            element.amf = data[0];
-            const result = element._computeUnionProperty(data[1], 0);
-            assert.typeOf(result, 'object');
-          });
+        it('Computes union type', async () => {
+          const [amf, type] = await AmfLoader.loadType('Unionable', item[1]);
+          element.amf = amf;
+          key = element._getAmfKey(element.ns.aml.vocabularies.shapes.anyOf);
+          const result = element._computeProperty(type, key, 0);
+          assert.typeOf(result, 'object');
         });
 
         it('Returns undefined when no type', () => {
-          const result = element._computeUnionProperty();
+          key = element._getAmfKey(element.ns.aml.vocabularies.shapes.anyOf);
+          const result = element._computeProperty(undefined, key, undefined);
           assert.isUndefined(result);
         });
 
         it('Returns undefined when no anyOf property', () => {
-          const result = element._computeUnionProperty({});
+          key = element._getAmfKey(element.ns.aml.vocabularies.shapes.anyOf);
+          const result = element._computeProperty({}, key, undefined);
           assert.isUndefined(result);
         });
 
-        it('Computes union type for an array item', () => {
-          return AmfLoader.loadType('UnionArray', item[1]).then((data) => {
-            element.amf = data[0];
-            const result = element._computeUnionProperty(data[1], 0);
-            assert.isTrue(
-              element._hasType(
-                result,
-                element.ns.aml.vocabularies.shapes.ScalarShape
-              )
-            );
-          });
+        it('Computes union type for an array item', async () => {
+          const [amf, type] = await AmfLoader.loadType('UnionArray', item[1]);
+          element.amf = amf;
+          key = element._getAmfKey(element.ns.aml.vocabularies.shapes.anyOf);
+          const result = element._computeProperty(type, key, 0);
+          assert.isTrue(
+            element._hasType(
+              result,
+              element.ns.aml.vocabularies.shapes.ScalarShape
+            )
+          );
         });
       });
 


### PR DESCRIPTION
Add support for the following OAS 3 keywords in types:
- `oneOf`
- `anyOf`

Show them in the same manner that Unions are shown, with buttons to change the selection of the different types involved.