### PR TITLE
Fix/apic 483

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@api-components/api-type-document",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@api-components/api-type-document",
   "description": "A documentation table for type (resource) properties. Works with AMF data model",
-  "version": "4.2.1",
+  "version": "4.2.2",
   "license": "Apache-2.0",
   "main": "index.js",
   "module": "index.js",

--- a/src/PropertyDocumentMixin.js
+++ b/src/PropertyDocumentMixin.js
@@ -17,6 +17,7 @@ import { AmfHelperMixin } from '@api-components/amf-helper-mixin';
 /* eslint-disable class-methods-use-this */
 /* eslint-disable no-param-reassign */
 /* eslint-disable prefer-destructuring */
+/* eslint-disable valid-jsdoc */
 
 /**
  * @typedef {Object} ArrayPropertyItem
@@ -289,7 +290,7 @@ const mxFunction = (base) => {
             if (this._hasType(item, skey)) {
               const rkey = this._getAmfKey(this.ns.w3.rdfSchema.key);
               const schemas = Object.keys(item).filter((k) =>
-                k.startsWith(`${rkey}_`)
+                k.startsWith(rkey)
               );
               schemas.forEach((s) => {
                 const schema = this._ensureArray(item[s]);

--- a/test/property-document-mixin.test.js
+++ b/test/property-document-mixin.test.js
@@ -388,12 +388,14 @@ describe('PropertyDocumentMixin', () => {
             {
               '@type': rkey,
               [`${skey}_1`]: [modelItem],
+              [`${skey}_2`]: [modelItem],
+              [`${skey}:_1`]: [modelItem],
             },
           ];
 
           const result = element._computeArrayProperties(model);
           assert.typeOf(result, 'array');
-          assert.lengthOf(result, 1);
+          assert.lengthOf(result, 3);
         });
       });
     });


### PR DESCRIPTION
When using JSON schema Datatype in RAML definition, we were only showing first level of JSON schema structure.
Schemas start with rdfs