### PR TITLE
Fix type display for partial model enum array

### DIFF
--- a/demo/aap-1698/aap-1698.raml
+++ b/demo/aap-1698/aap-1698.raml
@@ -1,0 +1,26 @@
+#%RAML 1.0
+title: AAP-1698
+
+/working:
+  post:
+    body:
+      application/json:
+        type: object
+        properties:
+          userType:
+            type:
+              enum: [Admin, User, System]
+            required: false
+
+/not-working:
+  post:
+    body:
+      application/json:
+        type: object
+        properties:
+          mappers:
+            description: optional set of mapper types to use for handling the request.
+            type: array
+            items:
+              enum: [ "lookup","ml","fasttext"]
+            required: false

--- a/demo/apis.json
+++ b/demo/apis.json
@@ -1,5 +1,6 @@
 {
   "demo-api/demo-api.raml": "RAML 1.0",
+  "aap-1698/aap-1698.raml": "RAML 1.0",
   "apic-83/apic-83.raml": "RAML 1.0",
   "oas-api/Petstore.yaml": "OAS 2.0",
   "examples-api/examples-api.raml": "RAML 1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@api-components/api-type-document",
-  "version": "4.2.2",
+  "version": "4.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -91,7 +91,10 @@
           "import/no-extraneous-dependencies": "off"
         }
       }
-    ]
+    ],
+    "rules": {
+      "prefer-destructuring": "off"
+    }
   },
   "prettier": {
     "singleQuote": true,

--- a/package.json
+++ b/package.json
@@ -93,7 +93,9 @@
       }
     ],
     "rules": {
-      "prefer-destructuring": "off"
+      "prefer-destructuring": "off",
+      "no-plusplus": "off",
+      "consistent-return": "off"
     }
   },
   "prettier": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@api-components/api-type-document",
   "description": "A documentation table for type (resource) properties. Works with AMF data model",
-  "version": "4.2.2",
+  "version": "4.2.3",
   "license": "Apache-2.0",
   "main": "index.js",
   "module": "index.js",

--- a/src/PropertyRangeDocument.js
+++ b/src/PropertyRangeDocument.js
@@ -172,7 +172,7 @@ export class PropertyRangeDocument extends PropertyDocumentMixin(LitElement) {
       [model] = model;
     }
     if (isArray) {
-      [model] = model[ikey];
+      model = model[ikey];
     }
     const results = [];
     Object.keys(model).forEach((key) => {

--- a/test/api-type-document.test.js
+++ b/test/api-type-document.test.js
@@ -893,6 +893,7 @@ describe('<api-type-document>', function () {
         [type] = getPayloadType(element, amf, '/not-working', 'post');
         element.type = type;
         await nextFrame();
+        await aTimeout(0);
       });
 
       it('renders array of enum strings property with partial model', () => {

--- a/test/api-type-document.test.js
+++ b/test/api-type-document.test.js
@@ -1,12 +1,12 @@
 import { fixture, assert, nextFrame, aTimeout } from '@open-wc/testing';
-import { AmfLoader } from './amf-loader.js';
 import { tap } from '@polymer/iron-test-helpers/mock-interactions.js';
+import { AmfLoader } from './amf-loader.js';
 import '../api-type-document.js';
 
 describe('<api-type-document>', function () {
   const newOas3Types = 'new-oas3-types';
   async function basicFixture() {
-    return await fixture(`<api-type-document></api-type-document>`);
+    return fixture(`<api-type-document></api-type-document>`);
   }
 
   function getPayloadType(element, model, path, methodName) {
@@ -707,7 +707,7 @@ describe('<api-type-document>', function () {
       });
 
       describe('readOnly properties', () => {
-        let element
+        let element;
 
         beforeEach(async () => {
           const data = await AmfLoader.loadType(
@@ -724,15 +724,21 @@ describe('<api-type-document>', function () {
         it('does not render the readOnly properties', async () => {
           element.renderReadOnly = false;
           await nextFrame();
-          assert.lengthOf(element.shadowRoot.querySelectorAll('property-shape-document'), 1);
+          assert.lengthOf(
+            element.shadowRoot.querySelectorAll('property-shape-document'),
+            1
+          );
         });
 
         it('renders the readOnly properties', async () => {
           element.renderReadOnly = true;
           await nextFrame();
-          assert.lengthOf(element.shadowRoot.querySelectorAll('property-shape-document'), 2);
+          assert.lengthOf(
+            element.shadowRoot.querySelectorAll('property-shape-document'),
+            2
+          );
         });
-      })
+      });
     });
   });
 
@@ -806,7 +812,7 @@ describe('<api-type-document>', function () {
 
   [
     ['Regular model - OAS 3 types additions', false],
-    ['Compact model - OAS 3 types additions', true]
+    ['Compact model - OAS 3 types additions', true],
   ].forEach(([name, compact]) => {
     describe(name, () => {
       let element;
@@ -816,7 +822,11 @@ describe('<api-type-document>', function () {
       });
 
       it('should represent type as oneOf', async () => {
-        const [amf, type] = await AmfLoader.loadType('Pet', compact, newOas3Types)
+        const [amf, type] = await AmfLoader.loadType(
+          'Pet',
+          compact,
+          newOas3Types
+        );
         element.amf = amf;
         element.type = type;
         await aTimeout(0);
@@ -825,17 +835,25 @@ describe('<api-type-document>', function () {
       });
 
       it('changes selectedOneOf when button clicked', async () => {
-        const [amf, type] = await AmfLoader.loadType('Pet', compact, newOas3Types)
+        const [amf, type] = await AmfLoader.loadType(
+          'Pet',
+          compact,
+          newOas3Types
+        );
         element.amf = amf;
         element.type = type;
         await aTimeout(0);
         assert.equal(element.selectedOneOf, 0);
-        element.shadowRoot.querySelectorAll('.one-of-toggle')[1].click()
+        element.shadowRoot.querySelectorAll('.one-of-toggle')[1].click();
         assert.equal(element.selectedOneOf, 1);
       });
 
       it('should represent type as anyOf', async () => {
-        const [amf, type] = await AmfLoader.loadType('Monster', compact, newOas3Types)
+        const [amf, type] = await AmfLoader.loadType(
+          'Monster',
+          compact,
+          newOas3Types
+        );
         element.amf = amf;
         element.type = type;
         await aTimeout(0);
@@ -844,13 +862,43 @@ describe('<api-type-document>', function () {
       });
 
       it('changes selectedAnyOf when button clicked', async () => {
-        const [amf, type] = await AmfLoader.loadType('Monster', compact, newOas3Types)
+        const [amf, type] = await AmfLoader.loadType(
+          'Monster',
+          compact,
+          newOas3Types
+        );
         element.amf = amf;
         element.type = type;
         await aTimeout(0);
         assert.equal(element.selectedAnyOf, 0);
-        element.shadowRoot.querySelectorAll('.any-of-toggle')[1].click()
+        element.shadowRoot.querySelectorAll('.any-of-toggle')[1].click();
         assert.equal(element.selectedAnyOf, 1);
+      });
+    });
+  });
+
+  [
+    ['Regular model - AAP-1698', false],
+    ['Compact model - AAP-1698', true],
+  ].forEach(([name, compact]) => {
+    describe(name, () => {
+      let element;
+      let amf;
+      let type;
+
+      beforeEach(async () => {
+        element = await basicFixture();
+        amf = await AmfLoader.load(compact, 'aap-1698');
+        element.amf = amf;
+        [type] = getPayloadType(element, amf, '/not-working', 'post');
+        element.type = type;
+        await nextFrame();
+      });
+
+      it('renders array of enum strings property with partial model', () => {
+        assert.exists(
+          element.shadowRoot.querySelector('property-shape-document')
+        );
       });
     });
   });


### PR DESCRIPTION
When using partial model to display a type that has an enum value array, property was not being showed.

Fixed how this value was obtained, added test case for where the bug surfaced.