### PR TITLE
Add font-weight variable to the attribute label

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,8 @@ Custom property | Description | Default
 ## Usage
 
 ### Installation
-```
+
+```sh
 npm install --save @api-components/api-type-document
 ```
 
@@ -108,6 +109,7 @@ npm start
 ```
 
 ### Running the tests
+
 ```sh
 npm test
 ```

--- a/src/RangeStyles.js
+++ b/src/RangeStyles.js
@@ -26,7 +26,7 @@ export default css`
   }
 
   .attribute-label {
-    font-weight: 500;
+    font-weight: var(--api-type-document-property-range-attribute-label-font-weight, 500);
     margin-right: 12px;
   }
 


### PR DESCRIPTION
When using a custom font that doesn't have the semibold weight, this attribute falls back to the normal weight and doesn't look right. Added `--api-type-document-property-range-attribute-label-font-weight` variable with fallback to 500 to make it possible to adjust the font-weight as necessary.