### PR TITLE
Add support for deprecated properties

### DIFF
--- a/demo/APIC-649/APIC-649.yaml
+++ b/demo/APIC-649/APIC-649.yaml
@@ -1,0 +1,118 @@
+openapi: "3.0.0"
+
+info:
+  description: This is a simple API
+  version: "1.0.0"
+  title: Simple Inventory API
+  contact:
+    email: you@your-company.com
+  license:
+    name: Apache 2.0
+    url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
+tags:
+  - name: admins
+    description: Secured Admin-only calls
+  - name: developers
+    description: Operations available to regular developers
+paths:
+  /inventory:
+    get:
+      tags:
+        - developers
+      summary: searches inventory
+      operationId: searchInventory
+      description: |
+        By passing in the appropriate options, you can search for
+        available inventory in the system
+      parameters:
+        - in: query
+          name: searchString
+          description: pass an optional search string for looking up inventory
+          required: false
+          schema:
+            type: string
+        - in: query
+          name: skip
+          description: number of records to skip for pagination
+          schema:
+            type: integer
+            format: int32
+            minimum: 0
+        - in: query
+          name: limit
+          description: maximum number of records to return
+          schema:
+            type: integer
+            format: int32
+            minimum: 0
+            maximum: 50
+      responses:
+        '200':
+          description: search results matching criteria
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/InventoryItem'
+        '400':
+          description: bad input parameter
+    post:
+      tags:
+        - admins
+      summary: adds an inventory item
+      operationId: addInventory
+      description: Adds an item to the system
+      responses:
+        '201':
+          description: item created
+        '400':
+          description: 'invalid input, object invalid'
+        '409':
+          description: an existing item already exists
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/InventoryItem'
+        description: Inventory item to add
+components:
+  schemas:
+    InventoryItem:
+      type: object
+      required:
+        - id
+        - name
+        - manufacturer
+        - releaseDate
+      properties:
+        id:
+          type: string
+          format: uuid
+          example: d290f1ee-6c54-4b01-90e6-d701748f0851
+        name:
+          type: string
+          example: Widget Adapter
+        releaseDate:
+          type: string
+          format: date-time
+          example: '2016-08-29T09:12:33.001Z'
+        manufacturer:
+          $ref: '#/components/schemas/Manufacturer'
+    Manufacturer:
+      required:
+        - name
+      properties:
+        name:
+          type: string
+          example: ACME Corporation
+          deprecated: true
+        homePage:
+          type: string
+          format: url
+          example: 'https://www.acme-corp.com'
+        phone:
+          type: string
+          example: 408-867-5309
+          deprecated: true
+      type: object

--- a/demo/apis.json
+++ b/demo/apis.json
@@ -14,5 +14,6 @@
   "APIC-429/APIC-429.yaml": { "type": "OAS 3.0", "mime": "application/yaml" },
   "SE-17897/SE-17897.yaml": { "type": "OAS 3.0", "mime": "application/yaml" },
   "new-oas3-types/new-oas3-types.yaml": { "type": "OAS 3.0", "mime": "application/yaml" },
-  "oas-api/read-only-properties.yaml": { "type": "OAS 3.0", "mime": "application/yaml" }
+  "oas-api/read-only-properties.yaml": { "type": "OAS 3.0", "mime": "application/yaml" },
+  "APIC-649/APIC-649.yaml": { "type": "OAS 3.0", "mime": "application/yaml" }
 }

--- a/demo/index.js
+++ b/demo/index.js
@@ -99,8 +99,9 @@ class ApiDemo extends ApiDemoPage {
 
   _apiListTemplate() {
     return [
-      ['APIC-429', 'APIC 429'],
       ['demo-api', 'Demo API'],
+      ['APIC-649', 'Deprecated properties'],
+      ['APIC-429', 'APIC 429'],
       ['read-only-properties', 'Read Only Properties API'],
       ['examples-api', 'Examples render demo'],
       ['Petstore', 'OAS: Petstore'],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@api-components/api-type-document",
-  "version": "4.2.11",
+  "version": "4.2.12",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@api-components/api-type-document",
-  "version": "4.2.10",
+  "version": "4.2.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -307,9 +307,9 @@
       }
     },
     "@api-components/amf-helper-mixin": {
-      "version": "4.3.11",
-      "resolved": "https://registry.npmjs.org/@api-components/amf-helper-mixin/-/amf-helper-mixin-4.3.11.tgz",
-      "integrity": "sha512-vmgbJnrXQikfozUKxxas8Re2Ok6y0/GH454J0GazAGxwzymx2EA+sxyrt12pT+p7fyu5CymUDt97sDBCdCTvzA=="
+      "version": "4.3.12",
+      "resolved": "https://registry.npmjs.org/@api-components/amf-helper-mixin/-/amf-helper-mixin-4.3.12.tgz",
+      "integrity": "sha512-BW1nDz5qcrid+TI6+opZNh6lxSnKkbuhpZZLRlAzmKOUIw59fbN12Nh8K/mxL760x4E8dsPhr2mReZ5chBR0pg=="
     },
     "@api-components/api-annotation-document": {
       "version": "4.2.0",
@@ -453,18 +453,18 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.5.tgz",
-      "integrity": "sha512-121rumjddw9c3NCQ55KGkyE1h/nzWhU/owjhw0l4mQrkzz4x9SGS1X8gFLraHwX7td3Yo4QTL+qj0NcIzN87BA==",
+      "version": "7.14.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.14.6.tgz",
+      "integrity": "sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==",
       "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
     },
     "@babel/runtime-corejs3": {
-      "version": "7.14.5",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.14.5.tgz",
-      "integrity": "sha512-cBbwXj3F2xjnQJ0ERaFRLjxhUSBYsQPXJ7CERz/ecx6q6hzQ99eTflAPFC3ks4q/IG4CWupNVdflc4jlFBJVsg==",
+      "version": "7.14.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.14.6.tgz",
+      "integrity": "sha512-Xl8SPYtdjcMoCsIM4teyVRg7jIcgl8F2kRtoCcXuHzXswt9UxZCS6BzRo8fcnCuP6u2XtPgvyonmEPF57Kxo9Q==",
       "dev": true,
       "requires": {
         "core-js-pure": "^3.14.0",
@@ -2921,9 +2921,9 @@
       }
     },
     "@web/browser-logs": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@web/browser-logs/-/browser-logs-0.2.3.tgz",
-      "integrity": "sha512-Ylp/5S07j1P/mO2EsCBMGJ8piwh2RWh9h4G/b1gapQvq85XaphjMA2S/dug4DOHJ15OdhMqbgVJPQ5edLXnW4w==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@web/browser-logs/-/browser-logs-0.2.4.tgz",
+      "integrity": "sha512-11DAAv8ZqbO267dwBLXtvmDoJXXucG5n+i9oQQEEVgbgXKOvK/7eqGhrSDKuZ7TTTkSci9fW7ZcuKFtaKskAIA==",
       "dev": true,
       "requires": {
         "errorstacks": "^2.2.0"
@@ -3634,19 +3634,19 @@
       "dev": true
     },
     "chokidar": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.1.tgz",
-      "integrity": "sha512-9+s+Od+W0VJJzawDma/gvBNQqkTiqYTWLuZoyAsivsI4AaWTCzHG06/TMjsf1cYe9Cb97UCEhjz7HvnPk2p/tw==",
+      "version": "3.5.2",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.2.tgz",
+      "integrity": "sha512-ekGhOnNVPgT77r4K/U3GDhu+FQ2S8TnK/s2KbIGXi0SZWuwkZ2QNyfWdZW+TVfn84DpEP7rLeCt2UI6bJ8GwbQ==",
       "dev": true,
       "requires": {
-        "anymatch": "~3.1.1",
+        "anymatch": "~3.1.2",
         "braces": "~3.0.2",
-        "fsevents": "~2.3.1",
-        "glob-parent": "~5.1.0",
+        "fsevents": "~2.3.2",
+        "glob-parent": "~5.1.2",
         "is-binary-path": "~2.1.0",
         "is-glob": "~4.0.1",
         "normalize-path": "~3.0.0",
-        "readdirp": "~3.5.0"
+        "readdirp": "~3.6.0"
       }
     },
     "chownr": {
@@ -8152,9 +8152,9 @@
       "dev": true
     },
     "readdirp": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.5.0.tgz",
-      "integrity": "sha512-cMhu7c/8rdhkHXWsY+osBhfSy0JikwpHK/5+imo+LpeasTF8ouErHrlYkwT0++njiyuDvc7OFY5T3ukvZ8qmFQ==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
       "dev": true,
       "requires": {
         "picomatch": "^2.2.1"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@api-components/api-type-document",
   "description": "A documentation table for type (resource) properties. Works with AMF data model",
-  "version": "4.2.11",
+  "version": "4.2.12",
   "license": "Apache-2.0",
   "main": "index.js",
   "module": "index.js",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@api-components/api-type-document",
   "description": "A documentation table for type (resource) properties. Works with AMF data model",
-  "version": "4.2.10",
+  "version": "4.2.11",
   "license": "Apache-2.0",
   "main": "index.js",
   "module": "index.js",

--- a/src/PropertyShapeDocument.d.ts
+++ b/src/PropertyShapeDocument.d.ts
@@ -133,6 +133,11 @@ export class PropertyShapeDocument extends  PropertyDocumentMixin(LitElement) {
    * @attribute
    */
   renderReadOnly: boolean;
+  /**
+   * Determines if shape's range is deprecated
+   * @attribute
+   */
+  deprecated: boolean
 
   get complexToggleLabel(): string;
 

--- a/src/PropertyShapeDocument.js
+++ b/src/PropertyShapeDocument.js
@@ -126,6 +126,7 @@ export class PropertyShapeDocument extends PropertyDocumentMixin(LitElement) {
        * Computed value from the shape. True if the property is an anyOf
        */
       isAnyOf: { type: Boolean },
+      deprecated: { type: Boolean, reflect: true },
     };
   }
 
@@ -208,6 +209,7 @@ export class PropertyShapeDocument extends PropertyDocumentMixin(LitElement) {
     this.hasPropertyDescription = false;
     this.narrow = false;
     this.renderReadOnly = false;
+    this.deprecated = false;
   }
 
   connectedCallback() {
@@ -268,6 +270,13 @@ export class PropertyShapeDocument extends PropertyDocumentMixin(LitElement) {
       this.propertyName
     );
     this.propertyDataType = this._computeObjectDataType(range, shape);
+    const isDeprecated = Boolean(this._computeIsDeprecated(range));
+    this.deprecated = isDeprecated;
+    console.log('is deprecated:', isDeprecated)
+  }
+
+  _computeIsDeprecated(range) {
+    return this._getValue(range, this._getAmfKey(this.ns.aml.vocabularies.shapes.deprecated))
   }
 
   _computeObjectDataType(range, shape) {
@@ -633,6 +642,13 @@ export class PropertyShapeDocument extends PropertyDocumentMixin(LitElement) {
       : ''}`;
   }
 
+  _deprecatedWarningTemplate() {
+    if (!this.deprecated) {
+      return '';
+    }
+    return html`<div class="deprecated-warning">Warning: This property has been deprecated</div>`
+  }
+
   /**
    * @return {TemplateResult} Main render function.
    */
@@ -665,6 +681,7 @@ export class PropertyShapeDocument extends PropertyDocumentMixin(LitElement) {
             >`
           : ''}
       </div>
+      ${this._deprecatedWarningTemplate()}
       ${this._descriptionTemplate()}
       <property-range-document
         .amf="${this.amf}"

--- a/src/PropertyShapeDocument.js
+++ b/src/PropertyShapeDocument.js
@@ -646,7 +646,7 @@ export class PropertyShapeDocument extends PropertyDocumentMixin(LitElement) {
     if (!this.deprecated) {
       return '';
     }
-    return html`<div class="deprecated-warning">Warning: This property has been deprecated</div>`
+    return html`<div class="deprecated-warning">Warning: Deprecated</div>`
   }
 
   /**

--- a/src/PropertyShapeDocument.js
+++ b/src/PropertyShapeDocument.js
@@ -126,6 +126,9 @@ export class PropertyShapeDocument extends PropertyDocumentMixin(LitElement) {
        * Computed value from the shape. True if the property is an anyOf
        */
       isAnyOf: { type: Boolean },
+      /**
+       * Determines if shape's range is deprecated
+       */
       deprecated: { type: Boolean, reflect: true },
     };
   }
@@ -272,7 +275,6 @@ export class PropertyShapeDocument extends PropertyDocumentMixin(LitElement) {
     this.propertyDataType = this._computeObjectDataType(range, shape);
     const isDeprecated = Boolean(this._computeIsDeprecated(range));
     this.deprecated = isDeprecated;
-    console.log('is deprecated:', isDeprecated)
   }
 
   _computeIsDeprecated(range) {

--- a/src/ShapeStyles.js
+++ b/src/ShapeStyles.js
@@ -164,4 +164,22 @@ export default css`
     background-color: var(--api-type-readonly-property-background-color, #ff9292);
     color: var(--api-type-readonly-property-color, black);
   }
+
+  :host([deprecated]) .property-title {
+    color: gray;
+    text-decoration: line-through;
+  }
+
+  :host([deprecated]) .property-traits > span {
+    background-color: var(--api-type-document-type-deprecated-background-color, gray);
+    color: var(--api-type-document-type-deprecated-color, white);
+  }
+
+  .deprecated-warning {
+    background-color: var(--api-type-document-deprecated-warning-background-color, rgb(150, 150, 150));
+    color: var(--api-type-document-deprecated-warning-color, rgb(50,50,50));
+    padding: var(--api-type-document-deprecated-warning-padding, 3px 6px);
+    border-radius: var(--api-type-document-deprecated-warning-border-radius, 3px);
+    display: inline-flex;
+  }
 `;

--- a/src/ShapeStyles.js
+++ b/src/ShapeStyles.js
@@ -176,8 +176,8 @@ export default css`
   }
 
   .deprecated-warning {
-    background-color: var(--api-type-document-deprecated-warning-background-color, rgb(150, 150, 150));
-    color: var(--api-type-document-deprecated-warning-color, rgb(50,50,50));
+    background-color: var(--api-type-document-type-deprecated-background-color, gray);
+    color: var(--api-type-document-type-deprecated-color, white);
     padding: var(--api-type-document-deprecated-warning-padding, 3px 6px);
     border-radius: var(--api-type-document-deprecated-warning-border-radius, 3px);
     display: inline-flex;

--- a/test/property-shape-document.test.js
+++ b/test/property-shape-document.test.js
@@ -676,6 +676,34 @@ describe('PropertyShapeDocument', () => {
     });
   });
 
+  describe('Deprecated properties', () => {
+    [
+      ['Regular model', false],
+      ['Compact model', true],
+    ].forEach(([label, compact]) => {
+      describe(String(label), () => {
+        let amf;
+        let type;
+
+        before(async () => {
+          [amf, type] = await AmfLoader.loadType('Manufacturer', compact, 'APIC-649');
+        });
+
+        it('should set `deprecated` property', async () => {
+          const shape = AmfLoader.lookupPropertyShape(amf, type, 'name');
+          const element = await modelFixture(amf, shape);
+          assert.isTrue(element.deprecated);
+        });
+
+        it('should set render deprecated warning message', async () => {
+          const shape = AmfLoader.lookupPropertyShape(amf, type, 'name');
+          const element = await modelFixture(amf, shape);
+          assert.exists(element.shadowRoot.querySelector('.deprecated-warning'));
+        });
+      });
+    });
+  });
+
   // this API does not produce amf_inline_type anymore
   // nor any inn the demos
   describe.skip('APIC-282', () => {


### PR DESCRIPTION
OAS 3 allows for settings properties as deprecated, which is different than the annotation support we have for RAML. In this proposal, I changed styles for deprecated properties, and added a warning message for those deprecated properties to let the user know that they are dealing with something that is deprecated.

Any ideas and/or suggestions as to how we can make the UI better for this are welcome. I tried to maintain some consistency with how the swagger editor displays it, as it seemed to work well in my opinion.