### PR TITLE
Fix/duplicated examples

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@api-components/api-type-document",
-  "version": "4.2.14",
+  "version": "4.2.15",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@api-components/api-type-document",
   "description": "A documentation table for type (resource) properties. Works with AMF data model",
-  "version": "4.2.14",
+  "version": "4.2.15",
   "license": "Apache-2.0",
   "main": "index.js",
   "module": "index.js",

--- a/src/ApiTypeDocument.d.ts
+++ b/src/ApiTypeDocument.d.ts
@@ -180,7 +180,7 @@ export class ApiTypeDocument extends PropertyDocumentMixin(LitElement) {
 
   connectedCallback(): void;
 
-  _computeRenderMainExample(noMainExample: boolean, hasExamples: boolean): boolean;
+  _computeRenderMainExample(noMainExample: boolean, hasExamples: boolean, isScalar: boolean): boolean;
 
   /**
    * Called when resolved type or amf changed.

--- a/src/ApiTypeDocument.js
+++ b/src/ApiTypeDocument.js
@@ -289,9 +289,11 @@ export class ApiTypeDocument extends PropertyDocumentMixin(LitElement) {
     }
     this.__hasExamples = value;
     this.requestUpdate('_hasExamples', old);
+    const scalarType = this._hasType(this.type, this.ns.aml.vocabularies.shapes.ScalarShape);
     this._renderMainExample = this._computeRenderMainExample(
       this.noMainExample,
-      value
+      value,
+      scalarType
     );
   }
 
@@ -337,8 +339,8 @@ export class ApiTypeDocument extends PropertyDocumentMixin(LitElement) {
     }
   }
 
-  _computeRenderMainExample(noMainExample, hasExamples) {
-    return !!(!noMainExample && hasExamples);
+  _computeRenderMainExample(noMainExample, hasExamples, isScalar = false) {
+    return isScalar ? false : !!(!noMainExample && hasExamples);
   }
 
   /**

--- a/test/api-type-document.test.js
+++ b/test/api-type-document.test.js
@@ -117,6 +117,11 @@ describe('<api-type-document>', () => {
         const result = element._computeRenderMainExample(true, true);
         assert.isFalse(result);
       });
+
+      it('Returns false when type is scalar', () => {
+        const result = element._computeRenderMainExample(true, true, true);
+        assert.isFalse(result);
+      });
     });
   });
 
@@ -563,6 +568,13 @@ describe('<api-type-document>', () => {
             'property-shape-document.union-document'
           );
           assert.notOk(doc);
+        });
+
+        it('Does not render main example', () => {
+          const examples = element.shadowRoot.querySelector(
+            'examples'
+          );
+          assert.notOk(examples);
         });
       });
 


### PR DESCRIPTION
The type document renders an example above the properties documentation. If a property has an example then it renders example for a property and it looks duplicated.
<img width="1680" alt="duplicatedExample" src="https://user-images.githubusercontent.com/13999213/127889058-df1e13ef-f2aa-4675-82e1-a97c0282d3bf.png">

Now, if the type is a scalar we hide the main example.