### PR TITLE
[W-11209734] Missing array length

### DIFF
--- a/demo/apis.json
+++ b/demo/apis.json
@@ -13,6 +13,7 @@
   "SE-19500/SE-19500.raml": "RAML 1.0",
   "enum-test/enum-test.raml": "RAML 1.0",
   "APIC-667/APIC-667.raml": "RAML 1.0",
+  "array-type/array-type.raml": "RAML 1.0",
   "APIC-429/APIC-429.yaml": { "type": "OAS 3.0", "mime": "application/yaml" },
   "SE-17897/SE-17897.yaml": { "type": "OAS 3.0", "mime": "application/yaml" },
   "new-oas3-types/new-oas3-types.yaml": { "type": "OAS 3.0", "mime": "application/yaml" },

--- a/demo/array-type/array-type.raml
+++ b/demo/array-type/array-type.raml
@@ -1,0 +1,18 @@
+#%RAML 1.0
+title: 00193743
+
+types:
+  Email:
+    type: object
+    properties:
+      name:
+        type: string
+  Emails:
+    type: array
+    items: Email
+    minItems: 1
+    maxItems: 3
+    uniqueItems: true
+  Other:
+    type: string
+    minLength: 2

--- a/demo/index.js
+++ b/demo/index.js
@@ -112,6 +112,7 @@ class ApiDemo extends ApiDemoPage {
       ['APIC-282', 'APIC-282'],
       ['new-oas3-types', 'New OAS 3 types API'],
       ['APIC-483', 'APIC 483'],
+      ['array-type', 'array-type'],
     ].map(
       ([file, label]) => html` <anypoint-item data-src="${file}-compact.json"
           >${label} - compact model</anypoint-item

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@api-components/api-type-document",
-  "version": "4.2.17",
+  "version": "4.2.18",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@api-components/api-type-document",
   "description": "A documentation table for type (resource) properties. Works with AMF data model",
-  "version": "4.2.17",
+  "version": "4.2.18",
   "license": "Apache-2.0",
   "main": "index.js",
   "module": "index.js",

--- a/src/ApiTypeDocument.js
+++ b/src/ApiTypeDocument.js
@@ -652,6 +652,25 @@ export class ApiTypeDocument extends PropertyDocumentMixin(LitElement) {
     );
   }
 
+  _arrayPropertyTemplate(label, value, title) {
+    return html`
+        <div class="property-attribute" part="property-attribute">
+          <span class="attribute-label" part="attribute-label">${label}</span>
+          <span class="attribute-value" part="attribute-value" title=${title}>${value}</span>
+        </div>
+        `
+  }
+
+  _arrayPropertiesTemplate() {
+    const minCount = this._getValue(this._resolvedType, this.ns.w3.shacl.minCount)
+    const maxCount = this._getValue(this._resolvedType, this.ns.w3.shacl.maxCount)
+
+    return html`
+      ${minCount !== undefined ? this._arrayPropertyTemplate('Minimum array length:', minCount, 'Minimum amount of items in array') : ''}
+      ${maxCount !== undefined ? this._arrayPropertyTemplate('Maximum array length:', maxCount, 'Maximum amount of items in array') : ''}
+    `
+  }
+
   /**
    * @return {TemplateResult} Templates for object properties
    */
@@ -688,15 +707,19 @@ export class ApiTypeDocument extends PropertyDocumentMixin(LitElement) {
           : ''}
       `
     );
-    if (!this.hasParentType) {
-      return html`
+
+    return html`
+      ${!this.hasParentType ?
+        html`
         <span>Array of:</span>
         <div class="array-children">
           ${documents}
-        </div>
-      `;
-    }
-    return html`${documents}`;
+        </div>` 
+        : html`${documents}`
+        }
+    
+      ${this._arrayPropertiesTemplate()}
+    `;
   }
 
   /**

--- a/src/TypeStyles.js
+++ b/src/TypeStyles.js
@@ -85,4 +85,15 @@ export default css`
   .union-type-selector {
     margin: 12px 0;
   }
+
+  .property-attribute {
+    margin: 4px 0;
+    padding: 0;
+    color: var(--api-type-document-type-attribute-color, #616161);
+  }
+
+  .attribute-label {
+    font-weight: var(--api-type-document-property-range-attribute-label-font-weight, 500);
+    margin-right: 12px;
+  }
 `;

--- a/test/api-type-document.test.js
+++ b/test/api-type-document.test.js
@@ -521,6 +521,39 @@ describe('<api-type-document>', () => {
         });
       });
 
+      describe('Array type with restrictions', () => {
+        let element = /** @type ApiTypeDocument */ (null);
+        beforeEach(async () => {
+          const data = await AmfLoader.loadType('Emails', item[1], 'array-type');
+          element = await basicFixture();
+          element.amf = data[0];
+          element.type = data[1];
+          await aTimeout(0);
+        });
+
+        it('isArray is true', () => {
+          assert.isTrue(element.isArray);
+        });
+
+        it('Renders array document', () => {
+          const doc = element.shadowRoot.querySelector(
+            'property-shape-document.array-document'
+          );
+          assert.ok(doc);
+        });
+
+        it('Renders minItems and maxItems info', () => {
+          const properties = element.shadowRoot.querySelectorAll(
+            '.property-attribute'
+          );
+          assert.lengthOf(properties, 2);
+          assert.equal(properties[0].querySelector('.attribute-label').innerText, 'Minimum array length:');
+          assert.equal(properties[0].querySelector('.attribute-value').innerText, '1');
+          assert.equal(properties[1].querySelector('.attribute-label').innerText, 'Maximum array length:');
+          assert.equal(properties[1].querySelector('.attribute-value').innerText, '3');
+        });
+      });
+
       describe('Scalar type', () => {
         let element = /** @type ApiTypeDocument */ (null);
 


### PR DESCRIPTION
Bug: When defining an array type with minItems and maxItems nodes, no info about length is documented.

Fix: If any of those properties are defined, a label is added right after the items info
<img width="222" alt="Screen Shot 2022-06-24 at 16 38 12" src="https://user-images.githubusercontent.com/13999213/175656713-51fce98c-81f4-423d-a523-64defa6e1aa5.png">
