### PR TITLE
[W-12137562] Object being incorrectly recursively rendered in type documentation

### DIFF
--- a/demo/W-12137562/W-12137562.raml
+++ b/demo/W-12137562/W-12137562.raml
@@ -1,0 +1,5 @@
+#%RAML 1.0
+title: api
+types:
+  Pet:
+    type: !include /pet.json

--- a/demo/W-12137562/pet.json
+++ b/demo/W-12137562/pet.json
@@ -1,0 +1,29 @@
+{
+  "title": "pet",
+  "description": "pet",
+  "examples": [
+    {
+      "animal": "pet"
+    }
+  ],
+  "type": "object",
+  "properties": {
+    "pet": {
+      "type": "string",
+      "oneOf": [
+        {
+          "const": "CT",
+          "description": "Cat"
+        },
+        {
+          "const": "DG",
+          "description": "Dog"
+        },
+        {
+          "const": "PT",
+          "description": "Parrot"
+        } 
+      ]
+    }
+  }
+}

--- a/demo/apis.json
+++ b/demo/apis.json
@@ -15,6 +15,7 @@
   "APIC-667/APIC-667.raml": "RAML 1.0",
   "array-type/array-type.raml": "RAML 1.0",
   "W-11858334/W-11858334.raml": "RAML 1.0",
+  "W-12137562/W-12137562.raml": "RAML 1.0",
   "APIC-429/APIC-429.yaml": { "type": "OAS 3.0", "mime": "application/yaml" },
   "SE-17897/SE-17897.yaml": { "type": "OAS 3.0", "mime": "application/yaml" },
   "new-oas3-types/new-oas3-types.yaml": { "type": "OAS 3.0", "mime": "application/yaml" },

--- a/demo/index.js
+++ b/demo/index.js
@@ -114,6 +114,7 @@ class ApiDemo extends ApiDemoPage {
       ['APIC-483', 'APIC 483'],
       ['array-type', 'array-type'],
       ['W-11858334', 'W-11858334'],
+      ['W-12137562', 'W-12137562'],
     ].map(
       ([file, label]) => html` <anypoint-item data-src="${file}-compact.json"
           >${label} - compact model</anypoint-item

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@api-components/api-type-document",
-  "version": "4.2.21",
+  "version": "4.2.22",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@api-components/api-type-document",
-      "version": "4.2.21",
+      "version": "4.2.22",
       "license": "Apache-2.0",
       "dependencies": {
         "@advanced-rest-client/arc-marked": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@api-components/api-type-document",
   "description": "A documentation table for type (resource) properties. Works with AMF data model",
-  "version": "4.2.21",
+  "version": "4.2.22",
   "license": "Apache-2.0",
   "main": "index.js",
   "module": "index.js",

--- a/src/ApiTypeDocument.js
+++ b/src/ApiTypeDocument.js
@@ -383,6 +383,12 @@ export class ApiTypeDocument extends PropertyDocumentMixin(LitElement) {
       this._hasType(type, this.ns.aml.vocabularies.shapes.NilShape)
     ) {
       isScalar = true;
+      if (this._hasProperty(type, this.ns.w3.shacl.xone)) {
+        isScalar = false;
+        isOneOf = true;
+        key = this._getAmfKey(this.ns.w3.shacl.xone);
+        this.oneOfTypes = this._computeTypes(type, key);
+      }
     } else if (
       this._hasType(type, this.ns.aml.vocabularies.shapes.UnionShape)
     ) {

--- a/test/W-12137562.test.js
+++ b/test/W-12137562.test.js
@@ -1,0 +1,47 @@
+/* eslint-disable prefer-destructuring */
+import {fixture, assert, aTimeout} from '@open-wc/testing'
+import { AmfLoader } from './amf-loader.js';
+import '../api-type-document.js';
+
+/** @typedef {import('..').ApiTypeDocument} ApiTypeDocument */
+/** @typedef {import('..').PropertyShapeDocument} PropertyShapeDocument */
+/** @typedef {import('@api-components/amf-helper-mixin').AmfDocument} AmfDocument */
+
+describe('<api-type-document>', () => {
+  const file = 'W-12137562';
+
+  /**
+   * @returns {Promise<ApiTypeDocument>}
+   */
+  async function basicFixture() {
+    return fixture(`<api-type-document></api-type-document>`);
+  }
+
+  [
+    ['Regular model', false],
+    ['Compact model', true],
+  ].forEach((item) => {
+    describe(String(item[0]), () => {
+      let element = /** @type ApiTypeDocument */ (null);
+      beforeEach(async () => {
+        element = await basicFixture();
+      });
+
+      it('renders complex element', async () => {
+        const data = await AmfLoader.loadType('Pet', item[1], file);
+        element.amf = data[0];
+        element.type = data[1];
+        await aTimeout(0);
+
+        const shape = element.shadowRoot.querySelector('property-shape-document')
+        assert.ok(shape);
+
+        /** @type HTMLElement */ (shape.shadowRoot.querySelector('.complex-toggle')).click();
+        await aTimeout(0);
+        await aTimeout(0);
+
+        assert.ok(shape.shadowRoot.querySelector('api-type-document.children.complex'));
+      });
+    });
+  });
+});


### PR DESCRIPTION
Bug: Object being incorrectly recursively rendered in type documentation
<img width="766" alt="Screenshot 2023-01-16 at 16 22 27" src="https://user-images.githubusercontent.com/13999213/212752602-eeefb18b-e643-4023-a6bf-0743721faed2.png">

Fix: Property has type ScalarShape but also Xone, in that case we should set isOneOf to true to show the list of possibilities. 
<img width="747" alt="Screenshot 2023-01-16 at 16 21 47" src="https://user-images.githubusercontent.com/13999213/212752781-eeeb2667-654b-4712-8aea-d63d2b629825.png">
