### PR TITLE
[W-13536254] Fix required fields

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@api-components/api-type-document",
-  "version": "4.2.23",
+  "version": "4.2.24",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@api-components/api-type-document",
-      "version": "4.2.23",
+      "version": "4.2.24",
       "license": "Apache-2.0",
       "dependencies": {
         "@advanced-rest-client/arc-marked": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@api-components/api-type-document",
   "description": "A documentation table for type (resource) properties. Works with AMF data model",
-  "version": "4.2.23",
+  "version": "4.2.24",
   "license": "Apache-2.0",
   "main": "index.js",
   "module": "index.js",

--- a/src/PropertyShapeDocument.js
+++ b/src/PropertyShapeDocument.js
@@ -411,7 +411,7 @@ export class PropertyShapeDocument extends PropertyDocumentMixin(LitElement) {
       ));
     }
     const data = this._getValue(shape, this.ns.w3.shacl.minCount);
-    return data !== undefined && data !== 0;
+    return data !== undefined && Number(data) !== 0;
   }
 
   /**


### PR DESCRIPTION
Bug: Showing some fields as required when they are not

Fix: minCount value in the model holds the minimum count constraint over the mapped property. It should be converted to integer to see its true value and then check if its greater than 0 to show as required.