### PR TITLE
[W-13547158] Empty any of list

### DIFF
--- a/demo/W-13547158/W-13547158.yaml
+++ b/demo/W-13547158/W-13547158.yaml
@@ -1,0 +1,57 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: OAS anyOf minimal test
+paths:
+  /fhir/nhi/v1/Patient:
+    description: Minimal test of a FHIR OAS Extension
+    get:
+      summary: Search all resources of type Patient based on a set of criteria
+      operationId: searchPatient
+      responses:
+        '200':
+          description: the resource being returned
+          content:
+            application/fhir+json:
+              schema:
+                $ref: '#/components/schemas/Patient'
+components:
+  schemas:
+    Patient:
+      type: object
+      description: The Patient resource exposed by the NHI.
+      properties:
+        extension-anyOf:
+          type: array
+          items:
+            anyOf:
+              - $ref: '#/components/schemas/Extension1'
+              - $ref: '#/components/schemas/Extension2'
+              - $ref: '#/components/schemas/Extension3'
+    Extension1:
+      type: object
+      description: Extension 1
+      properties:
+        ext1-item-1:
+          type: string
+        ext1-item-2:
+          type: string
+
+    Extension2:
+      type: object
+      description: Extension 1
+      properties:
+        ext2-item-1:
+          type: string
+        ext2-item-2:
+          type: string
+
+    Extension3:
+      type: object
+      description: Extension 1
+      properties:
+        ext3-item-1:
+          type: string
+        ext3-item-2:
+          type: string
+

--- a/demo/apis.json
+++ b/demo/apis.json
@@ -19,6 +19,7 @@
   "W-12428173/W-12428173.raml": "RAML 1.0",
   "APIC-429/APIC-429.yaml": { "type": "OAS 3.0", "mime": "application/yaml" },
   "SE-17897/SE-17897.yaml": { "type": "OAS 3.0", "mime": "application/yaml" },
+  "W-13547158/W-13547158.yaml": { "type": "OAS 3.0", "mime": "application/yaml" },
   "new-oas3-types/new-oas3-types.yaml": { "type": "OAS 3.0", "mime": "application/yaml" },
   "oas-api/read-only-properties.yaml": { "type": "OAS 3.0", "mime": "application/yaml" },
   "APIC-649/APIC-649.yaml": { "type": "OAS 3.0", "mime": "application/yaml" },

--- a/demo/index.js
+++ b/demo/index.js
@@ -116,6 +116,7 @@ class ApiDemo extends ApiDemoPage {
       ['W-11858334', 'W-11858334'],
       ['W-12137562', 'W-12137562'],
       ['W-12428173', 'W-12428173'],
+      ['W-13547158', 'W-13547158'],
     ].map(
       ([file, label]) => html` <anypoint-item data-src="${file}-compact.json"
           >${label} - compact model</anypoint-item

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@api-components/api-type-document",
-  "version": "4.2.24",
+  "version": "4.2.25",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@api-components/api-type-document",
   "description": "A documentation table for type (resource) properties. Works with AMF data model",
-  "version": "4.2.24",
+  "version": "4.2.25",
   "license": "Apache-2.0",
   "main": "index.js",
   "module": "index.js",

--- a/src/PropertyShapeDocument.js
+++ b/src/PropertyShapeDocument.js
@@ -295,8 +295,7 @@ export class PropertyShapeDocument extends PropertyDocumentMixin(LitElement) {
       this.propertyName
     );
     this.propertyDataType = this._computeObjectDataType(range, shape);
-    const isDeprecated = Boolean(this._computeIsDeprecated(range));
-    this.deprecated = isDeprecated;
+    this.deprecated = Boolean(this._computeIsDeprecated(range));
   }
 
   _computeIsDeprecated(range) {

--- a/test/api-type-document.test.js
+++ b/test/api-type-document.test.js
@@ -9,6 +9,7 @@ import '../api-type-document.js';
 
 describe('<api-type-document>', () => {
   const newOas3Types = 'new-oas3-types';
+  const oas3AnyOf = 'W-13547158';
 
   /**
    * @returns {Promise<ApiTypeDocument>}
@@ -994,6 +995,71 @@ describe('<api-type-document>', () => {
         assert.equal(element.selectedAnyOf, 0);
         /** @type HTMLElement */ (element.shadowRoot.querySelectorAll('.any-of-toggle')[1]).click();
         assert.equal(element.selectedAnyOf, 1);
+      });
+    });
+  });
+
+  [
+    ['Regular model - OAS 3 any of types', false],
+    ['Compact model - OAS 3 any of types', true],
+  ].forEach(([name, compact]) => {
+    describe(String(name), () => {
+      let element = /** @type ApiTypeDocument */ (null);
+
+      beforeEach(async () => {
+        element = await basicFixture();
+      });
+
+      it('should be an object type', async () => {
+        const [amf, type] = await AmfLoader.loadType(
+          'Patient',
+          compact,
+          oas3AnyOf
+        );
+        element.amf = amf;
+        element.type = type;
+        await aTimeout(0);
+        assert.equal(element.isObject, true);
+      });
+
+      it('should have anyOf properties', async () => {
+        const [amf, type] = await AmfLoader.loadType(
+          'Patient',
+          compact,
+          oas3AnyOf
+        );
+        element.amf = amf;
+        element.type = type;
+        await aTimeout(0);
+
+        const showButton = element.shadowRoot.querySelector('property-shape-document').shadowRoot.querySelector('anypoint-button.complex-toggle');
+        showButton.click();
+        await aTimeout(0);
+        await aTimeout(0);
+
+        const childrenType = element.shadowRoot.querySelector('property-shape-document').shadowRoot.querySelector('api-type-document');
+        assert.equal(childrenType.isAnyOf, true);
+      });
+
+      it('should list all anyOf options', async () => {
+        const [amf, type] = await AmfLoader.loadType(
+          'Patient',
+          compact,
+          oas3AnyOf
+        );
+        element.amf = amf;
+        element.type = type;
+        await aTimeout(0);
+
+        const showButton = element.shadowRoot.querySelector('property-shape-document').shadowRoot.querySelector('anypoint-button.complex-toggle');
+        showButton.click();
+        await aTimeout(0);
+        await aTimeout(0);
+
+        const childrenType = element.shadowRoot.querySelector('property-shape-document').shadowRoot.querySelector('api-type-document');
+        const unionTypes = childrenType.shadowRoot.querySelector('.union-type-selector');
+        const anyOfOptions = unionTypes.querySelectorAll('.any-of-toggle');
+        assert.equal(anyOfOptions.length, 3);
       });
     });
   });


### PR DESCRIPTION
Bug: When defining a schema with a property as a list of anyOf options, we were not showing the options available

e.g.
```
Patient:
      type: object
      description: The Patient resource exposed by the NHI.
      properties:
        extension-anyOf:
          type: array
          items:
            anyOf:
              - $ref: '#/components/schemas/Extension1'
              - $ref: '#/components/schemas/Extension2'
              - $ref: '#/components/schemas/Extension3'
```

Fix: correctly read amf model, this information is stored under **or** key

<img width="735" alt="Screenshot 2023-06-27 at 12 26 38" src="https://github.com/advanced-rest-client/api-type-document/assets/13999213/14fd37fc-24a5-42d0-bc20-36d81536f4a1">
