### PR TITLE
[W-13772034] Duplicated array info

### DIFF
--- a/demo/W-13770031/DataTypes/Kamino-library.raml
+++ b/demo/W-13770031/DataTypes/Kamino-library.raml
@@ -1,0 +1,20 @@
+#%RAML 1.0 Library
+usage:
+types:
+  1-post:
+    properties:
+      parent1:
+        description: 親要素にmaxItemsの指定あり
+        type: array
+        maxItems: 2
+
+        items:
+          properties:
+            child:
+              type: string
+            child2:
+              type: string[]
+              example:
+                - A
+                - B
+                - C

--- a/demo/W-13770031/ResourceTypes/Kamino1.raml
+++ b/demo/W-13770031/ResourceTypes/Kamino1.raml
@@ -1,0 +1,7 @@
+#%RAML 1.0 ResourceType
+
+post:
+  displayName: ANAUIUXS2_DEV-3915の調査
+  body:
+    application/json:
+      type: kaminoLib.1-post

--- a/demo/W-13770031/W-13770031.raml
+++ b/demo/W-13770031/W-13770031.raml
@@ -1,0 +1,11 @@
+#%RAML 1.0
+title: avnz_work
+
+resourceTypes:
+  kamino1: !include /ResourceTypes/Kamino1.raml
+
+uses:
+  kaminoLib: /DataTypes/Kamino-library.raml
+
+/kamino/1:
+  type: kamino1

--- a/demo/apis.json
+++ b/demo/apis.json
@@ -17,6 +17,7 @@
   "W-11858334/W-11858334.raml": "RAML 1.0",
   "W-12137562/W-12137562.raml": "RAML 1.0",
   "W-12428173/W-12428173.raml": "RAML 1.0",
+  "W-13770031/W-13770031.raml": "RAML 1.0",
   "APIC-429/APIC-429.yaml": { "type": "OAS 3.0", "mime": "application/yaml" },
   "SE-17897/SE-17897.yaml": { "type": "OAS 3.0", "mime": "application/yaml" },
   "W-13547158/W-13547158.yaml": { "type": "OAS 3.0", "mime": "application/yaml" },

--- a/demo/index.js
+++ b/demo/index.js
@@ -117,6 +117,7 @@ class ApiDemo extends ApiDemoPage {
       ['W-12137562', 'W-12137562'],
       ['W-12428173', 'W-12428173'],
       ['W-13547158', 'W-13547158'],
+      ['W-13770031', 'W-13770031'],
     ].map(
       ([file, label]) => html` <anypoint-item data-src="${file}-compact.json"
           >${label} - compact model</anypoint-item

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@api-components/api-type-document",
-  "version": "4.2.27",
+  "version": "4.2.28",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@api-components/api-type-document",
   "description": "A documentation table for type (resource) properties. Works with AMF data model",
-  "version": "4.2.27",
+  "version": "4.2.28",
   "license": "Apache-2.0",
   "main": "index.js",
   "module": "index.js",

--- a/src/ApiTypeDocument.d.ts
+++ b/src/ApiTypeDocument.d.ts
@@ -174,6 +174,8 @@ export class ApiTypeDocument extends PropertyDocumentMixin(LitElement) {
    */
   noMediaSelector: boolean;
 
+  noArrayInfo: boolean;
+
   get shouldRenderMediaSelector(): boolean;
 
   constructor();

--- a/src/ApiTypeDocument.js
+++ b/src/ApiTypeDocument.js
@@ -167,6 +167,8 @@ export class ApiTypeDocument extends PropertyDocumentMixin(LitElement) {
        * applicable.
        */
       noMediaSelector: { type: Boolean },
+
+      noArrayInfo: { type: Boolean },
     };
   }
 
@@ -685,13 +687,16 @@ export class ApiTypeDocument extends PropertyDocumentMixin(LitElement) {
   }
 
   _arrayPropertiesTemplate() {
-    const minCount = this._getValue(this._resolvedType, this.ns.w3.shacl.minCount)
-    const maxCount = this._getValue(this._resolvedType, this.ns.w3.shacl.maxCount)
+    if (!this.noArrayInfo) {
+      const minCount = this._getValue(this._resolvedType, this.ns.w3.shacl.minCount)
+      const maxCount = this._getValue(this._resolvedType, this.ns.w3.shacl.maxCount)
 
-    return html`
-      ${minCount !== undefined ? this._arrayPropertyTemplate('Minimum array length:', minCount, 'Minimum amount of items in array') : ''}
-      ${maxCount !== undefined ? this._arrayPropertyTemplate('Maximum array length:', maxCount, 'Maximum amount of items in array') : ''}
-    `
+      return html`
+          ${minCount !== undefined ? this._arrayPropertyTemplate('Minimum array length:', minCount, 'Minimum amount of items in array') : ''}
+          ${maxCount !== undefined ? this._arrayPropertyTemplate('Maximum array length:', maxCount, 'Maximum amount of items in array') : ''}
+      `
+    }
+    return html``
   }
 
   /**

--- a/src/PropertyShapeDocument.js
+++ b/src/PropertyShapeDocument.js
@@ -582,6 +582,7 @@ export class PropertyShapeDocument extends PropertyDocumentMixin(LitElement) {
       ?compatibility="${this.compatibility}"
       ?noExamplesActions="${this.noExamplesActions}"
       noMainExample
+      noArrayInfo
       .mediaType="${this.mediaType}"
       ?graph="${this.graph}"
     ></api-type-document>`;


### PR DESCRIPTION
Duplicated array info (shown before and after array properties).

Before:
<img width="769" alt="Screenshot 2023-08-03 at 16 51 12" src="https://github.com/advanced-rest-client/api-type-document/assets/13999213/1b7163b6-d572-4c95-8973-2fc51bd57dad">

After:
<img width="760" alt="Screenshot 2023-08-03 at 16 51 25" src="https://github.com/advanced-rest-client/api-type-document/assets/13999213/a62f02fe-e4a4-4953-b0c7-7302e7ed33a3">
